### PR TITLE
include launchpad install/reset bypass variables

### DIFF
--- a/infra/launchpad.tf
+++ b/infra/launchpad.tf
@@ -28,8 +28,8 @@ locals {
 resource "launchpad_config" "cluster" {
   # Tell the launchpad provider to not bother uninstalling
   # the container products on terraform destroy operations.
-  skip_destroy = true
-  skip_create  = false
+  skip_destroy = var.mke_skip_uninstall
+  skip_create  = var.mke_skip_install
 
   metadata {
     name = var.name

--- a/infra/provision/nodes.tf
+++ b/infra/provision/nodes.tf
@@ -4,7 +4,7 @@ module "nodegroups" {
 
   source = "./nodegroup"
 
-  name = each.key
+  name = "${var.name}-${each.key}"
 
   ami              = each.value.ami
   type             = each.value.type

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -107,3 +107,14 @@ variable "extra_tags" {
   default     = {}
 }
 
+variable "mke_skip_install" {
+  description = ""
+  type = bool
+  default = false
+}
+
+variable "mke_skip_uninstall" {
+  description = ""
+  type = bool
+  default = false
+}


### PR DESCRIPTION
- using these vars allows the launchpad resource to skip install so that you can test the infra, without having to remove the launchpad resource, if the launchpad install fails